### PR TITLE
Fix: Remove unused type ignore comment in test_settings.py

### DIFF
--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -146,7 +146,7 @@ class TestChunkingConfig:
 
         # Invalid method should fail
         with pytest.raises(ValidationError):
-            ChunkingConfig(method="invalid_method")  # type: ignore[arg-type]
+            ChunkingConfig(method="invalid_method")
 
 
 class TestProcessingConfig:


### PR DESCRIPTION
Removed unused '# type: ignore[arg-type]' comment from line 149 of `tests/unit/config/test_settings.py` that was flagged by mypy as 'unused-ignore'.

## Validation
- mypy src/ passes with no issues found in 35 source files
- ruff check --fix src/ tests/ passes all checks

Resolves #21

Generated with [Claude Code](https://claude.ai/code)