### PR TITLE
Fix: Add null checks for union attribute access violations

### DIFF
--- a/tests/integration/test_document_processing.py
+++ b/tests/integration/test_document_processing.py
@@ -431,6 +431,7 @@ class TestDocumentProcessingErrors:
 
             # Should handle permission error gracefully
             assert result.success is False
+            assert result.error is not None
             error_msg = result.error.lower()
             assert "permission" in error_msg or "access" in error_msg
 
@@ -479,6 +480,7 @@ class TestDocumentProcessingErrors:
 
             # Should handle size limit gracefully
             assert result.success is False
+            assert result.error is not None
             error_msg = result.error.lower()
             assert "too large" in error_msg or "size" in error_msg
 
@@ -489,6 +491,7 @@ class TestDocumentProcessingErrors:
         result = processor.process_document(nonexistent_file, "nonexistent-test")
 
         assert result.success is False
+        assert result.error is not None
         error_msg = result.error.lower()
         assert "not found" in error_msg or "does not exist" in error_msg
 
@@ -499,6 +502,7 @@ class TestDocumentProcessingErrors:
         result = processor.process_document(temp_dir, "directory-test")
 
         assert result.success is False
+        assert result.error is not None
         error_msg = result.error.lower()
         assert "directory" in error_msg or "not a file" in error_msg
 
@@ -512,7 +516,7 @@ class TestDocumentProcessingErrors:
         result = processor.process_document(empty_file, "empty-test")
 
         assert result.success is False
-        assert "empty" in result.error.lower()
+        assert result.error and "empty" in result.error.lower()
 
     def test_whitespace_only_file(
         self, processor: DocumentProcessor, temp_dir: Path
@@ -527,6 +531,7 @@ class TestDocumentProcessingErrors:
         if result.success:
             assert result.chunks_created == 0
         else:
+            assert result.error is not None
             error_msg = result.error.lower()
             assert "empty" in error_msg or "no content" in error_msg
 

--- a/tests/unit/core/test_processor.py
+++ b/tests/unit/core/test_processor.py
@@ -108,7 +108,7 @@ class TestDocumentProcessor:
         result = processor.process_document(empty_file, "test-collection")
 
         assert result.success is False
-        assert "empty" in result.error.lower()
+        assert result.error and "empty" in result.error.lower()
 
     def test_process_document_large_file(
         self, processor: DocumentProcessor, temp_dir: Path
@@ -123,7 +123,7 @@ class TestDocumentProcessor:
             result = processor.process_document(large_file, "test-collection")
 
             assert result.success is False
-            assert "too large" in result.error.lower()
+            assert result.error and "too large" in result.error.lower()
 
     def test_process_document_no_chunks_generated(
         self,
@@ -143,7 +143,7 @@ class TestDocumentProcessor:
         result = processor.process_document(sample_markdown_file, "test-collection")
 
         assert result.success is False
-        assert "no chunks generated" in result.error.lower()
+        assert result.error and "no chunks generated" in result.error.lower()
         assert result.chunks_created == 0
 
     def test_process_document_parsing_error(
@@ -158,7 +158,7 @@ class TestDocumentProcessor:
         result = processor.process_document(sample_markdown_file, "test-collection")
 
         assert result.success is False
-        assert "parsing failed" in result.error.lower()
+        assert result.error and "parsing failed" in result.error.lower()
 
     def test_process_document_encoding_error(
         self, processor: DocumentProcessor, temp_dir: Path
@@ -172,7 +172,9 @@ class TestDocumentProcessor:
 
         # Should handle encoding gracefully
         assert result.success is False
-        assert "decode" in result.error.lower() or "encoding" in result.error.lower()
+        assert result.error and (
+            "decode" in result.error.lower() or "encoding" in result.error.lower()
+        )
 
     def test_read_file_multiple_encodings(
         self, processor: DocumentProcessor, temp_dir: Path


### PR DESCRIPTION
**Summary**
- Fixed 11 union-attr MyPy errors by adding null checks before calling `.lower()` on potentially None values
- Modified test assertions to safely access `result.error` attributes
- Maintained test logic functionality with safe access patterns

**Files Changed**
- `tests/unit/core/test_processor.py` (5 fixes)
- `tests/integration/test_document_processing.py` (6 fixes)

**Validation**
- MyPy type checking passes with no errors
- Ruff linting passes
- Test collection successful

Resolves issue #22

Generated with [Claude Code](https://claude.ai/code)