### PR TITLE
fix: Resolve CI/CD cache failures (Issue #31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   PYTHON_VERSION: "3.12"
-  UV_CACHE_DIR: /tmp/.uv-cache
 
 jobs:
   # Code quality checks
@@ -38,6 +37,9 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+        continue-on-error: true
 
       - name: Run pre-commit
         run: uv run pre-commit run --all-files


### PR DESCRIPTION
## Summary
- Removes conflicting `UV_CACHE_DIR` environment variable that causes GitHub Cache API 400 errors
- Enhances pre-commit cache configuration with proper fallback mechanisms
- Adds `continue-on-error: true` to prevent cache failures from breaking builds

## Problem
The CI/CD pipeline was experiencing cache failures due to conflicts between the manually set `UV_CACHE_DIR` environment variable and the `setup-uv@v3` action's internal cache management system. This was causing:
- GitHub Cache API 400 errors
- Slower CI builds (2-3 minutes additional time)
- Potential build failures

## Solution
1. **Removed conflicting environment variable**: Deleted `UV_CACHE_DIR: /tmp/.uv-cache` from the global environment, allowing `setup-uv@v3` to manage UV caching internally
2. **Enhanced pre-commit cache**: Added `restore-keys` fallback mechanism to improve cache hit rates
3. **Added error handling**: Set `continue-on-error: true` for pre-commit cache to prevent cache issues from failing the entire build

## Test Plan
- [x] Verify YAML syntax is valid
- [x] Confirm all existing cache configurations remain functional
- [x] Ensure no functional changes to CI/CD behavior beyond caching improvements
- [x] Pre-commit hooks pass successfully
- [ ] Monitor CI builds after merge for improved performance and reduced errors

## References
- Closes #31
- Related to ongoing CI/CD optimization efforts

## Expected Impact
- **Performance**: 2-3 minutes faster CI builds due to improved cache efficiency
- **Reliability**: Elimination of GitHub Cache API 400 errors
- **Maintainability**: Simplified cache configuration that relies on action defaults

🤖 Generated with [Claude Code](https://claude.ai/code)