### PR TITLE
refactor: Remove --use-mock CLI option from user interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,13 @@ jobs:
         run: uv sync --dev --extra chromadb
 
       - name: Run unit tests
+        env:
+          SHARD_MD_USE_MOCK_CHROMADB: "true" # Use mock for unit tests (no external dependencies)
         run: uv run pytest tests/unit/ -v --tb=short --strict-markers
 
       - name: Run integration tests (without ChromaDB)
+        env:
+          SHARD_MD_USE_MOCK_CHROMADB: "true" # Use mock for tests not requiring real ChromaDB
         run: uv run pytest tests/integration/ -v --tb=short --strict-markers -m "not chromadb"
 
       - name: Upload test results
@@ -317,6 +321,8 @@ jobs:
         run: uv sync --dev
 
       - name: Run benchmarks
+        env:
+          SHARD_MD_USE_MOCK_CHROMADB: "true" # Use mock for consistent benchmark measurements
         run: uv run pytest tests/performance/ --benchmark-only --benchmark-json=benchmark.json
 
       - name: Upload benchmark results
@@ -462,6 +468,7 @@ jobs:
         env:
           CHROMA_HOST: localhost
           CHROMA_PORT: 8000
+          SHARD_MD_USE_MOCK_CHROMADB: "false" # Use real ChromaDB for integration tests
         run: |
           echo "🧪 Running integration tests that require ChromaDB"
           uv run pytest tests/integration/ -v --tb=short --strict-markers -m "chromadb" || echo "No tests marked with chromadb in integration"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -181,6 +181,8 @@ jobs:
 
       - name: Run tests with updated dependencies
         if: steps.update.outputs.changes == 'true'
+        env:
+          SHARD_MD_USE_MOCK_CHROMADB: "true" # Use mock for unit tests (faster, no external dependencies)
         run: |
           uv sync --dev
           uv run pytest tests/unit/ --tb=short

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
         env:
           CHROMA_HOST: localhost
           CHROMA_PORT: 8000
+          SHARD_MD_USE_MOCK_CHROMADB: "false" # Ensure real ChromaDB is used for release testing
         run: |
           # Run tests and capture the exit code
           uv run pytest \

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -451,7 +451,9 @@ find docs/ -name "*.md" | tail -n +101 | head -100 | xargs shard-md process --co
 curl http://localhost:8000/api/v1/heartbeat
 
 # Use mock client for testing
-shard-md process --use-mock --collection test *.md
+# For testing with mock ChromaDB, set environment variable:
+# export SHARD_MD_USE_MOCK_CHROMADB=true
+shard-md process --collection test *.md
 ```
 
 #### Permission Denied

--- a/src/shard_markdown/cli/commands/process.py
+++ b/src/shard_markdown/cli/commands/process.py
@@ -76,11 +76,6 @@ console = Console()
     "--collection-metadata",
     help="Additional metadata for new collections (JSON format)",
 )
-@click.option(
-    "--use-mock",
-    is_flag=True,
-    help="Force use of mock ChromaDB client for testing",
-)
 @click.pass_context
 def process(  # noqa: C901
     ctx: click.Context,
@@ -94,7 +89,6 @@ def process(  # noqa: C901
     clear_collection: bool,
     dry_run: bool,
     collection_metadata: str | None,
-    use_mock: bool,
 ) -> None:
     """Process markdown files into ChromaDB collections.
 
@@ -114,9 +108,6 @@ def process(  # noqa: C901
 
       # Create new collection and clear it first
       shard-md process -c new-docs --create-collection --clear-collection *.md
-
-      # Use mock ChromaDB for testing
-      shard-md process -c test-docs --use-mock *.md
     """
     # Handle cases where ctx.obj might be None (e.g., in tests)
     if ctx.obj is None:
@@ -148,7 +139,7 @@ def process(  # noqa: C901
 
         # Setup ChromaDB and collection
         chroma_client, collection_obj = _setup_chromadb_and_collection(
-            config, use_mock, collection, clear_collection, create_collection
+            config, collection, clear_collection, create_collection
         )
 
         # Initialize processor
@@ -189,7 +180,6 @@ def _validate_and_prepare(
 
 def _setup_chromadb_and_collection(
     config: Any,
-    use_mock: bool,
     collection: str,
     clear_collection: bool,
     create_collection: bool,
@@ -197,7 +187,7 @@ def _setup_chromadb_and_collection(
     """Set up ChromaDB client and collection."""
     from ...utils.errors import ChromaDBError, NetworkError
 
-    chroma_client = create_chromadb_client(config.chromadb, use_mock=use_mock)
+    chroma_client = create_chromadb_client(config.chromadb)
     try:
         if not chroma_client.connect():
             raise click.ClickException("Failed to connect to ChromaDB")


### PR DESCRIPTION
## Summary
- Removed the `--use-mock` CLI option that was incorrectly exposed to end users
- Replaced with environment variable `SHARD_MD_USE_MOCK_CHROMADB` for testing purposes
- Updated all GitHub Actions workflows to use the environment variable appropriately

## Breaking Change
⚠️ **BREAKING**: The `--use-mock` CLI option has been removed. Test environments should now use the `SHARD_MD_USE_MOCK_CHROMADB` environment variable instead.

## Changes Made
1. **CLI Interface**: Removed `--use-mock` option from the `process` command
2. **ChromaDB Factory**: Simplified to only check environment variable
3. **GitHub Actions**: Updated all workflows to explicitly set the mock environment variable where needed
4. **Documentation**: Updated deployment guide to show environment variable usage

## Testing Strategy
- **Unit Tests**: Use `SHARD_MD_USE_MOCK_CHROMADB=true` for fast, dependency-free testing
- **Integration Tests**: Use real ChromaDB where needed (`false`) and mock where not (`true`)
- **E2E Tests**: Always use real ChromaDB (`false`) for production validation
- **Release Tests**: Always use real ChromaDB (`false`) to ensure production readiness

## Motivation
The `--use-mock` option was a testing/development flag that should never have been exposed in the user-facing CLI. This change properly separates testing concerns from the production interface.

🤖 Generated with [Claude Code](https://claude.ai/code)