### PR TITLE
chore: update .gitignore for local development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,11 @@ docs/build.log
 # Development artifacts
 *_FIX_SUMMARY.md
 *_SOLUTION.md
+
+# Planning and analysis files
+plans/
+baseline_lines.txt
+baseline_lint.txt
+baseline_tests.txt
+final_lines.txt
+final_tests.txt


### PR DESCRIPTION
## Summary
- Updated .gitignore to exclude local development and planning files
- Added exclusions for `plans/` directory and analysis `.txt` files
- Ensures these files remain local-only and aren't tracked in the repository

## Changes
- Added `plans/` directory to .gitignore
- Added baseline analysis files (`baseline_lines.txt`, `baseline_lint.txt`, `baseline_tests.txt`)
- Added final analysis files (`final_lines.txt`, `final_tests.txt`)

## Test Plan
- [x] Verified .gitignore patterns correctly exclude specified files
- [x] Confirmed files remain accessible locally
- [x] Tested git status shows files as ignored

🤖 Generated with [Claude Code](https://claude.ai/code)